### PR TITLE
Make searching Language correctly

### DIFF
--- a/Math/OEIS/Internal.hs
+++ b/Math/OEIS/Internal.hs
@@ -76,9 +76,9 @@ addElement ('A', x) c = c { author      = x                  }
 addElement ('O', x) c = c { offset      = read o
                           , firstGT1    = read f }
   where (o,f) = second tail . span (/=',') $ x
-addElement ('p', x) c = c { programs    = (Mathematica, x) :
+addElement ('p', x) c = c { programs    = (Maple, x) :
                                             programs c     }
-addElement ('t', x) c = c { programs    = (Maple, x) :
+addElement ('t', x) c = c { programs    = (Mathematica, x) :
                                             programs c     }
 addElement ('o', x) c = c { programs    = (Other, x) :
                                             programs c     }

--- a/Math/OEIS/Types.hs
+++ b/Math/OEIS/Types.hs
@@ -6,7 +6,7 @@ type SequenceData = [Integer]
 -- in. The only languages indicated natively by the OEIS database are
 -- Mathematica and Maple; any other languages will be listed (usually in
 -- parentheses) at the beginning of the actual code snippet.
-data Language = Mathematica | Maple | Other deriving Show
+data Language = Mathematica | Maple | Other deriving (Show, Eq)
 
 -- | OEIS keywords. For more information on the meaning of each keyword, see
 -- <http://oeis.org/eishelp2.html#RK>.


### PR DESCRIPTION
To get Meple function from OEIS, I want to use `lookup` for `Maple :: Language`.

But, `No instance for (Eq Language)`.
So, Make `Language` an instance of the `Eq` for looking 

And then, I did the following.

```haskell
ghci>(lookup Maple . programs) =<< lookupSequenceByID "A000001"
Just "FiniteGroupCount[Range[100]] (* _Harvey P. Dale_, Jan 29 2013 *)"
```
This result `"FiniteGroupCount[Range[100]] (* _Harvey P. Dale_, Jan 29 2013 *)"` is not Maple but Mathematica function. Similar results were obtained by other IDs.

So, swap conditions of `Maple` and `Mathematica` in `addElement`.