### PR TITLE
add support for multiple results

### DIFF
--- a/Math/OEIS.hs
+++ b/Math/OEIS.hs
@@ -8,6 +8,7 @@ module Math.OEIS
   , getSequenceByID_IO, lookupSequenceByID_IO
   , extendSequence_IO,  lookupSequence_IO
   , searchSequence_IO,  lookupOEIS
+  , searchSequences_IO, lookupSequences_IO
 
     -- * Data structures
   , SequenceData
@@ -42,7 +43,12 @@ lookupOEIS a = do
 
 -- | Look up a sequence in the OEIS using its search function.
 searchSequence_IO :: String -> IO (Maybe OEISSequence)
-searchSequence_IO x = getOEIS (baseSearchURI ++) (escapeURIString isAllowedInURI x)
+searchSequence_IO x = listToMaybe <$> searchSequences_IO x
+
+-- | Look up sequences in the OEIS using its search function (returns up to
+-- 10 results).
+searchSequences_IO :: String -> IO [OEISSequence]
+searchSequences_IO x = getOEIS (baseSearchURI ++) (escapeURIString isAllowedInURI x)
 
 -- | Look up a sequence in the OEIS by its catalog number. Generally this would
 -- be its A-number, but M-numbers (from the /Encyclopedia of Integer
@@ -88,7 +94,7 @@ lookupSequenceByID = unsafePerformIO . lookupSequenceByID_IO
 
 -- | The same as 'lookupSequenceByID', but in the 'IO' monad.
 lookupSequenceByID_IO :: String -> IO (Maybe OEISSequence)
-lookupSequenceByID_IO = getOEIS idSearchURI
+lookupSequenceByID_IO x = listToMaybe <$> getOEIS idSearchURI x
 
 -- | Extend a sequence by using it as a lookup to the OEIS, taking the first
 -- sequence returned as a result, and using it to augment the original
@@ -146,7 +152,11 @@ lookupSequence = unsafePerformIO . lookupSequence_IO
 
 -- | The same as 'lookupSequence', but in the 'IO' monad.
 lookupSequence_IO :: SequenceData -> IO (Maybe OEISSequence)
-lookupSequence_IO = getOEIS seqSearchURI
+lookupSequence_IO x = listToMaybe <$> lookupSequences_IO x
+
+-- | Similar to 'lookupSequence_IO', but return up to 10 results.
+lookupSequences_IO :: SequenceData -> IO [OEISSequence]
+lookupSequences_IO = getOEIS seqSearchURI
 
 --------------------------------------------------------------------------------
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -35,17 +35,17 @@ test_parseOEIS :: IO ()
 test_parseOEIS = do
     r0 <- readFileUtf8 "test/data/id_rsp.txt"
     case parseOEIS r0 of
-      Nothing -> assertFailure ""
-      Just r  -> do
+      [r]  -> do
           check r
           examples r @?= []
+      _ -> assertFailure ""
 
     r1 <- readFileUtf8 "test/data/seq_rsp.txt"
     case parseOEIS r1 of
-      Nothing -> assertFailure ""
-      Just r  -> do
+      [r,_,_,_,_,_,_,s,_,_]  -> do
           check r
-          assertBool "" $ not $ null $ examples r
+          assertBool "" $ not $ null $ examples s
+      _ -> assertFailure ""
   where
     check r = do
         catalogNums r @?= ["A000040","M0652","N0241"]


### PR DESCRIPTION
The OEIS text-based interface can return up to 10 results.
With this patch, the data is split into chunks at the %I fields,
and each chunk is parsed separately.

The existing functions only return the first result (previously,
the sequence data of all results would be concatenated...).

This patch adds new functions that can return multiple results:

  Math.OEIS.searchSequences_IO
  Math.OEIS.lookupSequences_IO